### PR TITLE
feat: Add getPacks method to retrieve installed CodeQL packs

### DIFF
--- a/src/services/codeqlService.ts
+++ b/src/services/codeqlService.ts
@@ -971,7 +971,7 @@ export class CodeQLService {
 
     // Build the query suite argument
     // var queries = `codeql/${language}-queries`;
-    var queries = await this.findQueryPack(language);
+    const queries = await this.findQueryPack(language);
     this.logger.info(
       "CodeQLService",
       `Using query pack: ${queries} for language: ${language}`


### PR DESCRIPTION
This pull request introduces enhancements to the `CodeQLService` class, focusing on improving the handling of CodeQL packs and query pack selection. The changes include the addition of a new method to retrieve installed CodeQL packs, refactoring of the query pack selection logic to leverage this new method, and improved error handling and logging.

### Enhancements to CodeQL pack handling:

* **Added `getPacks` method**: This new method retrieves a list of installed CodeQL packs using the CodeQL CLI, with detailed logging and error handling. It parses the CLI output to extract pack names and ensures no duplicates are included.

### Refactoring of query pack selection:

* **Refactored `findQueryPack` method**: The method was converted to an asynchronous function that now uses the `getPacks` method to identify the appropriate query pack for a given language. It prioritizes language-specific packs and falls back to a default pack if none are found. Enhanced logging provides better visibility into the selection process.

* **Updated usage of `findQueryPack`**: The call to `findQueryPack` in the `runAnalysis` method was updated to support its new asynchronous implementation.